### PR TITLE
Code: Remove unsupported Python 2.6 and 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,14 @@
 # See:
 #   https://docs.travis-ci.com/user/customizing-the-build/
 #   https://docs.travis-ci.com/user/languages/python
-#   http://lint.travis-ci.org
+#   https://lint.travis-ci.org
 
 language: python
 
 python:
   - "pypy"
   - "pypy3"
-  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
@@ -29,8 +27,6 @@ sudo: false
 install:
  - pip install 'setuptools>=17.1'
  - pip install 'mock>=2.0'
- - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then pip install unittest2; fi
- # Expecting Coverage to fail for pypy3 until Travis supports PyPy3 5.5+ (as of May 2017)
  - pip install coverage
 
 script:

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ see: dir for humans
 
 .. see/docs <summary>
 
-**see** is an alternative to ``dir()``, for Python 2.6+ and 3.3+.
+**see** is an alternative to ``dir()``, for Python 2.7 and 3.4+.
 
 It neatly summarises what you can do with an object.
 Use it to inspect your code or learn new APIs.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ coverage==4.4.1
 flake8==3.3.0
 pylint==1.7.1
 Sphinx==1.6.1
-unittest2==1.1.0
 virtualenv==15.1.0

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ VERSION = '1.4.1'
 INSTALL_REQUIRES = []
 TESTS_REQUIRE = [
     'mock>=2.0.0' if sys.version_info < (3, 3) else None,
-    'unittest2>=1.1.0' if sys.version_info < (2, 7) else None,
 ]
 
 with codecs.open('README.rst', encoding='utf-8') as file:
@@ -36,9 +35,9 @@ setup(name='see',
           'License :: OSI Approved :: BSD License',
           'Natural Language :: English',
           'Operating System :: OS Independent',
-          'Programming Language :: Python :: 2.6',
+          'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 2.7',
-          'Programming Language :: Python :: 3.3',
+          'Programming Language :: Python :: 3',
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5',
           'Programming Language :: Python :: 3.6',

--- a/tests/test_mod_inspector.py
+++ b/tests/test_mod_inspector.py
@@ -2,10 +2,7 @@
 Unit tests for the see.inspector module.
 
 """
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from see import inspector, output, see
 

--- a/tests/test_mod_output.py
+++ b/tests/test_mod_output.py
@@ -3,11 +3,7 @@ Unit tests for the see.output module.
 
 """
 import re
-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from see import output, see
 from see.features import PY3

--- a/tests/test_mod_term.py
+++ b/tests/test_mod_term.py
@@ -2,10 +2,7 @@
 Unit tests for the see.term module.
 
 """
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from see import term
 

--- a/tests/test_mod_tools.py
+++ b/tests/test_mod_tools.py
@@ -3,11 +3,7 @@ Unit tests for the see.tools module.
 
 """
 import re
-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from see import tools
 

--- a/tests/test_see_result.py
+++ b/tests/test_see_result.py
@@ -3,11 +3,7 @@ Unit tests for the result of calling see() with various types of object.
 
 """
 import itertools
-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from see import see
 

--- a/tests/test_term_width.py
+++ b/tests/test_term_width.py
@@ -10,16 +10,12 @@ loads see.
 import platform
 import sys
 from imp import reload
+import unittest
 
 try:
-    import unittest2 as unittest
+    import unittest.mock as mock  # Python 3.3+
 except ImportError:
-    import unittest
-
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
+    import mock  # Python 2
 
 try:
     import builtins  # Python 3

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -6,10 +6,7 @@ Unit tests for Unicode issues.
 This requires Unicode string literals in Python 2.
 
 """
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from see import output, tools
 from see.features import PY3


### PR DESCRIPTION
See #14 for docs changes.

## Reasons for dropping old ones

* https://en.wikipedia.org/wiki/CPython#Version_history

### 2.6

* https://snarky.ca/stop-using-python-2-6/
* http://www.curiousefficiency.org/posts/2015/04/stop-supporting-python26.html
* Current pip 9 deprecates Python 2.6 support, pip 10 won't support it (https://github.com/pypa/pip/issues/3955)
* Not much PyPI traffic (June 2016) https://github.com/pypa/pip/issues/3796

### 3.3

* pip 10 will deprecate Python 3.3 support, pip 11 won't support it (https://github.com/pypa/pip/issues/3796)
* Very little PyPI traffic (June 2016) https://github.com/pypa/pip/issues/3796

---

Also removed this comment because Travis now supports it:

`# Expecting Coverage to fail for pypy3 until Travis supports PyPy3 5.5+ (as of May 2017)`