### PR TITLE
Docs: Remove unsupported Python 2.6 and 3.3

### DIFF
--- a/_sources/install.rst.txt
+++ b/_sources/install.rst.txt
@@ -4,7 +4,7 @@
 Installation
 ============
 
-**see** supports Python 2.6+ and 3.3+.
+**see** supports Python 2.7 and 3.4+.
 
 The latest release can be found on the
 `Python Package Index <https://pypi.python.org/pypi/see>`_.

--- a/index.html
+++ b/index.html
@@ -5,12 +5,12 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    
+
     <title>see: dir for humans &#8212; see 1.4.1 documentation</title>
-    
+
     <link rel="stylesheet" href="_static/alabaster.css" type="text/css" />
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
-    
+
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    './',
@@ -27,16 +27,16 @@
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />
     <link rel="next" title="Installation" href="install.html" />
-   
+
   <link rel="stylesheet" href="_static/custom.css" type="text/css" />
-  
-  
+
+
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9" />
 
   </head>
   <body>
   <div class="document">
-    
+
       <div class="sphinxsidebar" role="navigation" aria-label="main navigation">
         <div class="sphinxsidebarwrapper">
 <h1 class="logo"><a href="#">see</a></h1>
@@ -81,13 +81,13 @@
       <div class="documentwrapper">
         <div class="bodywrapper">
           <div class="body" role="main">
-            
+
   <div class="section" id="module-see">
 <span id="see-dir-for-humans"></span><h1>see: dir for humans<a class="headerlink" href="#module-see" title="Permalink to this headline">¶</a></h1>
 <p>Release v1.4.1.</p>
 <a class="reference external image-reference" href="https://travis-ci.org/ljcooke/see"><img alt="https://travis-ci.org/ljcooke/see.svg?branch=develop" src="https://travis-ci.org/ljcooke/see.svg?branch=develop" /></a>
 <a class="reference external image-reference" href="https://coveralls.io/github/ljcooke/see?branch=develop"><img alt="https://coveralls.io/repos/github/ljcooke/see/badge.svg?branch=develop" src="https://coveralls.io/repos/github/ljcooke/see/badge.svg?branch=develop" /></a>
-<p><strong>see</strong> is an alternative to <code class="docutils literal"><span class="pre">dir()</span></code>, for Python 2.6+ and 3.3+.</p>
+<p><strong>see</strong> is an alternative to <code class="docutils literal"><span class="pre">dir()</span></code>, for Python 2.7 and 3.4+.</p>
 <p>It neatly summarises what you can do with an object.
 Use it to inspect your code or learn new APIs.</p>
 <p>To get started, see the <a class="reference internal" href="install.html"><span class="doc">Installation</span></a> and <a class="reference internal" href="usage.html"><span class="doc">Usage</span></a> pages.</p>
@@ -191,11 +191,11 @@ or a regular expression:</p>
   </div>
     <div class="footer">
       &copy;2009–2017, Liam Cooke.
-      
+
     </div>
 
-    
 
-    
+
+
   </body>
 </html>

--- a/install.html
+++ b/install.html
@@ -5,12 +5,12 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    
+
     <title>Installation &#8212; see 1.4.1 documentation</title>
-    
+
     <link rel="stylesheet" href="_static/alabaster.css" type="text/css" />
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
-    
+
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    './',
@@ -28,16 +28,16 @@
     <link rel="search" title="Search" href="search.html" />
     <link rel="next" title="Usage" href="usage.html" />
     <link rel="prev" title="see: dir for humans" href="index.html" />
-   
+
   <link rel="stylesheet" href="_static/custom.css" type="text/css" />
-  
-  
+
+
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9" />
 
   </head>
   <body>
   <div class="document">
-    
+
       <div class="sphinxsidebar" role="navigation" aria-label="main navigation">
         <div class="sphinxsidebarwrapper">
 <h1 class="logo"><a href="index.html">see</a></h1>
@@ -87,10 +87,10 @@
       <div class="documentwrapper">
         <div class="bodywrapper">
           <div class="body" role="main">
-            
+
   <div class="section" id="installation">
 <span id="index-0"></span><h1>Installation<a class="headerlink" href="#installation" title="Permalink to this headline">¶</a></h1>
-<p><strong>see</strong> supports Python 2.6+ and 3.3+.</p>
+<p><strong>see</strong> supports Python 2.7 and 3.4+.</p>
 <p>The latest release can be found on the
 <a class="reference external" href="https://pypi.python.org/pypi/see">Python Package Index</a>.</p>
 <div class="section" id="install-with-pip">
@@ -125,11 +125,11 @@ imported when you start Python.</p>
   </div>
     <div class="footer">
       &copy;2009–2017, Liam Cooke.
-      
+
     </div>
 
-    
 
-    
+
+
   </body>
 </html>


### PR DESCRIPTION
See #13 for code changes.

## Reasons for dropping old ones

* https://en.wikipedia.org/wiki/CPython#Version_history

### 2.6

* https://snarky.ca/stop-using-python-2-6/
* http://www.curiousefficiency.org/posts/2015/04/stop-supporting-python26.html
* Current pip 9 deprecates Python 2.6 support, pip 10 won't support it (https://github.com/pypa/pip/issues/3955)
* Not much PyPI traffic (June 2016) https://github.com/pypa/pip/issues/3796

### 3.3

* pip 10 will deprecate Python 3.3 support, pip 11 won't support it (https://github.com/pypa/pip/issues/3796)
* Very little PyPI traffic (June 2016) https://github.com/pypa/pip/issues/3796
