### PR TITLE
Updates for Python 2.7/3.4+

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,11 +12,6 @@ environment:
       PYTHON_ARCH: "64"
       TOXENV: "py27"
 
-    - PYTHON: "C:\\Python33-x64"
-      PYTHON_VERSION: "3.3.x"
-      PYTHON_ARCH: "64"
-      TOXENV: "py33"
-
     - PYTHON: "C:\\Python34-x64"
       PYTHON_VERSION: "3.4.x"
       PYTHON_ARCH: "64"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ VERSION = '1.4.1'
 
 INSTALL_REQUIRES = []
 TESTS_REQUIRE = [
-    'mock>=2.0.0' if sys.version_info < (3, 3) else None,
+    'mock>=2.0.0' if sys.version_info.major == 2 else None,
 ]
 
 with codecs.open('README.rst', encoding='utf-8') as file:
@@ -22,6 +22,7 @@ setup(name='see',
       platforms=['any'],
       url='https://ljcooke.github.io/see/',
       packages=['see'],
+      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
       install_requires=list(filter(bool, INSTALL_REQUIRES)),
       test_suite='tests',
       tests_require=list(filter(bool, TESTS_REQUIRE)),

--- a/tests/test_mod_inspector.py
+++ b/tests/test_mod_inspector.py
@@ -4,7 +4,7 @@ Unit tests for the see.inspector module.
 """
 import unittest
 
-from see import inspector, output, see
+from see import inspector, see
 
 
 class ObjectWithAttributeError(object):

--- a/tests/test_mod_inspector.py
+++ b/tests/test_mod_inspector.py
@@ -103,6 +103,7 @@ class TestSeeFunction(unittest.TestCase):
         filtered_result_pos_arg = see(obj, '*', pattern)
 
         # Assert
+        self.assertEqual(filtered_result, filtered_result_pos_arg)
         self.assertIn('.count()', filtered_result)
         self.assertNotIn('.pop()', filtered_result)
 

--- a/tests/test_see_result.py
+++ b/tests/test_see_result.py
@@ -12,7 +12,7 @@ def union(*sets):
     return set(itertools.chain(*sets))
 
 
-SIGN_OPS = set(['+obj', '-obj'])
+SIGN_OPS = {'+obj', '-obj'}
 
 NUMBER_OPS = set('+ - * / // % **'.split())
 NUMBER_ASSIGN_OPS = set()
@@ -22,8 +22,8 @@ BITWISE_ASSIGN_OPS = set(op + '=' for op in BITWISE_OPS)
 
 COMPARE_OPS = set('< <= == != > >='.split())
 
-MATRIX_OPS = set(['@'])
-MATRIX_ASSIGN_OPS = set(['@='])
+MATRIX_OPS = {'@'}
+MATRIX_ASSIGN_OPS = {'@='}
 
 ALL_OPS = union(
     SIGN_OPS,

--- a/tests/test_see_result.py
+++ b/tests/test_see_result.py
@@ -18,7 +18,7 @@ NUMBER_OPS = set('+ - * / // % **'.split())
 NUMBER_ASSIGN_OPS = set()
 
 BITWISE_OPS = set('<< >> & ^ | ~'.split())
-BITWISE_ASSIGN_OPS = set(op + '=' for op in BITWISE_OPS)
+BITWISE_ASSIGN_OPS = {op + '=' for op in BITWISE_OPS}
 
 COMPARE_OPS = set('< <= == != > >='.split())
 

--- a/tests/test_term_width.py
+++ b/tests/test_term_width.py
@@ -85,7 +85,7 @@ class TestSupportedTerminal(unittest.TestCase):
             return
 
         package = 'see.term.fcntl.ioctl'
-        with mock.patch(package, side_effect=IOError('')) as patch:
+        with mock.patch(package, side_effect=IOError('')):
             width = term.term_width()
 
             self.assertIsNone(width)


### PR DESCRIPTION
Changes proposed in this pull request:

- Don't test AppVeyor on Python 3.3
- Add python_requires to help pip
- Simplify some version checks
- Remove unused imports and variables
- Rewrite some unnecessary literals and generators, now possible with Python 2.7/3.4+
